### PR TITLE
Make example.env compatible with bash source.

### DIFF
--- a/example.env
+++ b/example.env
@@ -17,11 +17,11 @@ EMAIL_NOREPLY=noreply@yoursite.com
 
 COMPANY_EMAIL=support@yoursite.com
 COMPANY_URL=https://yoursite.com
-COMPANY_NAME=My Company Name
-COMPANY_TAG_LINE=Development - Awesome Site
+COMPANY_NAME="My Company Name"
+COMPANY_TAG_LINE="Development - Awesome Site"
 COMPANY_PHONE=1-123-12-12
 
-SENDGRID_API_KEY:123ssd12121sdfsd4f5sd4s54df5s4df54sd5f45sd41
+SENDGRID_API_KEY=123ssd12121sdfsd4f5sd4s54df5s4df54sd5f45sd41
 SENDGRID_USER_NAME=username
 SENDGRID_PASSWORD=userpassword
 


### PR DESCRIPTION
I was trying to use the example.env in a bash terminal to test out the api but there were a few lines in the environment settings that were not compatible with bash.

In the bash terminal I was doing the following...

> set -a; source example.env; set +a; node papaslive.js

The strings with spaces needed to be in quotes and there was a line that had a : separator instead of =